### PR TITLE
create deploy directory if it does not exist

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -4,6 +4,11 @@ cd AppInspector
 sencha app build production -c
 cd ..
 
+if [ ! -d "./deploy" ]; then
+    # create the directory if it does not exist
+    mkdir "./deploy"
+fi
+
 cp -R AppInspector/build/production/AI ./deploy/AppInspector
 
 cp background.* ./deploy


### PR DESCRIPTION
create the `./deploy` directory if it does not exists
fixes `cp ...` errors messages 
