### PR TITLE
Added i18n mechanism and locale file of Japanese.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -3,3 +3,4 @@
 * [Bruno Tavares](https://github.com/brunotavares) http://bruno.tavares.me (Creator)
 * [Arthur Kay](https://github.com/arthurakay) http://www.akawebdesign.com
 * [Stefan Stölzle](https://github.com/stoe) http://stefan.stoelzle.me
+* [Shinobu Kawano](https://github.com/kawanoshinobu) http://kawanoshinobu.com

--- a/app/AppInspector/about.html
+++ b/app/AppInspector/about.html
@@ -14,4 +14,5 @@
     <li><a href="http://www.akawebdesign.com" target="_blank">Arthur Kay</a></li>
     <li><a href="http://stefan.stoelzle.me" target="_blank">Stefan Stölzle</a></li>
     <li><a href="http://bruno.tavares.me" target="_blank">Bruno Tavares</a></li>
+    <li><a href="http://kawanoshinobu.com" target="_blank">Shinobu Kawano</a></li>
 </ul>

--- a/app/AppInspector/app.js
+++ b/app/AppInspector/app.js
@@ -20,6 +20,10 @@ Ext.Loader.setConfig({
 
 
 Ext.application({
+
+    requires: [
+        'AI.util.i18n'
+    ],
     controllers: [
         'Main',
         'Components',

--- a/app/AppInspector/app/util/i18n.js
+++ b/app/AppInspector/app/util/i18n.js
@@ -1,0 +1,88 @@
+/**
+ * Utility class for i18n.
+ */
+Ext.define('AI.util.i18n', {
+    singleton: true,
+
+    /**
+     * The list of property to convert value.
+     * @type {Array}
+     */
+    TARGET_PROPERTIES: [
+        'text',
+        'title',
+        'name'
+    ],
+
+    /**
+     * Overrides internal mechanism of class system.
+     */
+    constructor: function() {
+        var me = this;
+
+        Ext.define('AI.override.AbstractComponent', {
+            override: 'Ext.AbstractComponent',
+            constructor: function(config) {
+                me.convert(config);
+                this.callParent(arguments);
+            }
+        });
+    },
+
+    /**
+     * Return localized message which is converted by chrome i18n.
+     * @param  {String} value
+     * @return {String}
+     */
+    getMessage: function(value) {
+        var messageKey = this.convertMessageKey(value);
+        return chrome.i18n.getMessage(messageKey) || value || '';
+    },
+
+    /**
+     * Convert value to use the chrome i18n message key.
+     * If it contains spaces, be replaced '_' string.
+     * @private
+     * @param  {String} value
+     * @return {String}
+     */
+    convertMessageKey: function(value) {
+        return value.replace(/\s/g, '_');
+    },
+
+    /**
+     * Update value by i18n message.
+     * The Target is 'text', 'title' and 'name' property.
+     * @private
+     * @param  {Object} config
+     */
+    convert: function(config) {
+        var me    = this,
+            keys  = Object.keys(config),
+            key   = '',
+            value = '';
+
+        for (var i = keys.length - 1; i >= 0; i--) {
+            key   = keys[i];
+            value = config[key];
+
+            if (!me.isTargetProperty(key)) {
+                continue;
+            }
+
+            if (Ext.isString(value)) {
+                config[key] = me.getMessage(value);
+            }
+        }
+    },
+
+    /**
+     * @private
+     * @param  {String}  key
+     * @return {Boolean}
+     */
+    isTargetProperty: function(key) {
+        return Ext.Array.contains(AI.util.i18n.TARGET_PROPERTIES, key);
+    }
+
+});

--- a/app/AppInspector/app/util/i18n.js
+++ b/app/AppInspector/app/util/i18n.js
@@ -14,6 +14,9 @@ Ext.define('AI.util.i18n', {
         'name'
     ],
 
+    REGEXP_SPACE : /\s/g,
+    REGEXP_PERIOD: /\./g,
+
     /**
      * Overrides internal mechanism of class system.
      */
@@ -42,12 +45,14 @@ Ext.define('AI.util.i18n', {
     /**
      * Convert value to use the chrome i18n message key.
      * If it contains spaces, be replaced '_' string.
+     * If it contains period, be trimmed.
      * @private
      * @param  {String} value
      * @return {String}
      */
     convertMessageKey: function(value) {
-        return value.replace(/\s/g, '_');
+        return value.replace(AI.util.i18n.REGEXP_SPACE, '_').
+                    replace(AI.util.i18n.REGEXP_PERIOD, '');
     },
 
     /**

--- a/app/AppInspector/app/view/About.js
+++ b/app/AppInspector/app/view/About.js
@@ -66,10 +66,21 @@ Ext.define('AI.view.About', {
                     title: 'About App Inspector for Sencha',
                     titleCollapse: true
                 }
-            ]
+            ],
+            listeners: {
+                beforeadd: {
+                    fn: me.onAboutBeforeAdd,
+                    scope: me
+                }
+            }
         });
 
         me.callParent(arguments);
+    },
+
+    onAboutBeforeAdd: function(container, component, index, eOpts) {
+        this.setTitle(AI.util.i18n.getMessage(this.title));
+
     }
 
 });

--- a/app/AppInspector/app/view/Components.js
+++ b/app/AppInspector/app/view/Components.js
@@ -71,10 +71,21 @@ Ext.define('AI.view.Components', {
                         }
                     ]
                 }
-            ]
+            ],
+            listeners: {
+                beforeadd: {
+                    fn: me.onComponentInspectorBeforeAdd,
+                    scope: me
+                }
+            }
         });
 
         me.callParent(arguments);
+    },
+
+    onComponentInspectorBeforeAdd: function(container, component, index, eOpts) {
+        this.setTitle(AI.util.i18n.getMessage(this.title));
+
     }
 
 });

--- a/app/AppInspector/app/view/Events.js
+++ b/app/AppInspector/app/view/Events.js
@@ -84,10 +84,21 @@ Ext.define('AI.view.Events', {
                     text: 'Cmp ID',
                     flex: 1
                 }
-            ]
+            ],
+            listeners: {
+                beforeadd: {
+                    fn: me.onEventInspectorBeforeAdd,
+                    scope: me
+                }
+            }
         });
 
         me.callParent(arguments);
+    },
+
+    onEventInspectorBeforeAdd: function(container, component, index, eOpts) {
+        this.setTitle(AI.util.i18n.getMessage(this.title));
+
     }
 
 });

--- a/app/AppInspector/app/view/FilterField.js
+++ b/app/AppInspector/app/view/FilterField.js
@@ -40,6 +40,10 @@ Ext.define('AI.view.FilterField', {
                 keypress: {
                     fn: me.onTextfieldKeypress,
                     scope: me
+                },
+                beforerender: {
+                    fn: me.onTextfieldBeforeRender,
+                    scope: me
                 }
             }
         });
@@ -59,6 +63,11 @@ Ext.define('AI.view.FilterField', {
         if (this.forceEnter === true && e.getKey() === Ext.EventObject.ENTER) {
             this.fireEvent('applyfilter', textfield, textfield.getValue());
         }
+    },
+
+    onTextfieldBeforeRender: function(component, eOpts) {
+        this.emptyText = AI.util.i18n.getMessage(this.emptyText);
+
     }
 
 });

--- a/app/AppInspector/app/view/Layouts.js
+++ b/app/AppInspector/app/view/Layouts.js
@@ -137,10 +137,21 @@ Ext.define('AI.view.Layouts', {
                         }
                     ]
                 }
-            ]
+            ],
+            listeners: {
+                beforeadd: {
+                    fn: me.onLayoutInspectorBeforeAdd,
+                    scope: me
+                }
+            }
         });
 
         me.callParent(arguments);
+    },
+
+    onLayoutInspectorBeforeAdd: function(container, component, index, eOpts) {
+        this.setTitle(AI.util.i18n.getMessage(this.title));
+
     }
 
 });

--- a/app/AppInspector/app/view/Layouts.js
+++ b/app/AppInspector/app/view/Layouts.js
@@ -77,9 +77,10 @@ Ext.define('AI.view.Layouts', {
                                     xtype: 'button',
                                     handler: function(button, e) {
                                         Ext.Msg.alert(
-                                        'Overnesting',
-                                        'Utility to find components which may be overnested inside the application.'
+                                        AI.util.i18n.getMessage('Overnesting'),
+                                        AI.util.i18n.getMessage('Utility to find components which may be overnested inside the application.')
                                         );
+
                                     },
                                     text: '?'
                                 }
@@ -127,9 +128,10 @@ Ext.define('AI.view.Layouts', {
                                     xtype: 'button',
                                     handler: function(button, e) {
                                         Ext.Msg.alert(
-                                        'Box Layouts',
-                                        'Utility to find nested box layouts inside the application which may contribute to performance issues.'
+                                        AI.util.i18n.getMessage('Box Layouts'),
+                                        AI.util.i18n.getMessage('Utility to find nested box layouts inside the application which may contribute to performance issues.')
                                         );
+
                                     },
                                     text: '?'
                                 }

--- a/app/AppInspector/app/view/Stores.js
+++ b/app/AppInspector/app/view/Stores.js
@@ -125,10 +125,21 @@ Ext.define('AI.view.Stores', {
                         }
                     ]
                 }
-            ]
+            ],
+            listeners: {
+                beforeadd: {
+                    fn: me.onStoreInspectorBeforeAdd,
+                    scope: me
+                }
+            }
         });
 
         me.callParent(arguments);
+    },
+
+    onStoreInspectorBeforeAdd: function(container, component, index, eOpts) {
+        this.setTitle(AI.util.i18n.getMessage(this.title));
+
     }
 
 });

--- a/app/AppInspector/metadata/Application
+++ b/app/AppInspector/metadata/Application
@@ -13,7 +13,10 @@
             "Layouts",
             "Events"
         ],
-        "name": "AI"
+        "name": "AI",
+        "requires": [
+            "AI.util.i18n"
+        ]
     },
     "designerId": "application"
 }

--- a/app/AppInspector/metadata/view/About
+++ b/app/AppInspector/metadata/view/About
@@ -73,6 +73,24 @@
                 "width": null
             },
             "designerId": "711195df-b751-425b-ae80-7600476ded26"
+        },
+        {
+            "type": "basiceventbinding",
+            "reference": {
+                "name": "listeners",
+                "type": "array"
+            },
+            "codeClass": null,
+            "userConfig": {
+                "fn": "onAboutBeforeAdd",
+                "implHandler": [
+                    "this.setTitle(AI.util.i18n.getMessage(this.title));",
+                    ""
+                ],
+                "name": "beforeadd",
+                "scope": "me"
+            },
+            "designerId": "8a2fb92c-19fa-4f8b-8433-00ddc992f31f"
         }
     ]
 }

--- a/app/AppInspector/metadata/view/Components
+++ b/app/AppInspector/metadata/view/Components
@@ -130,6 +130,24 @@
                     ]
                 }
             ]
+        },
+        {
+            "type": "basiceventbinding",
+            "reference": {
+                "name": "listeners",
+                "type": "array"
+            },
+            "codeClass": null,
+            "userConfig": {
+                "fn": "onComponentInspectorBeforeAdd",
+                "implHandler": [
+                    "this.setTitle(AI.util.i18n.getMessage(this.title));",
+                    ""
+                ],
+                "name": "beforeadd",
+                "scope": "me"
+            },
+            "designerId": "5ec2a06c-d550-426d-a34b-2d9915d8acd3"
         }
     ]
 }

--- a/app/AppInspector/metadata/view/Events
+++ b/app/AppInspector/metadata/view/Events
@@ -141,6 +141,24 @@
             },
             "codeClass": null,
             "designerId": "037fc65d-5897-426c-969c-4cc723122d14"
+        },
+        {
+            "type": "basiceventbinding",
+            "reference": {
+                "name": "listeners",
+                "type": "array"
+            },
+            "codeClass": null,
+            "userConfig": {
+                "fn": "onEventInspectorBeforeAdd",
+                "implHandler": [
+                    "this.setTitle(AI.util.i18n.getMessage(this.title));",
+                    ""
+                ],
+                "name": "beforeadd",
+                "scope": "me"
+            },
+            "designerId": "dbd8eddb-03cb-44a9-b94c-c13e8de50958"
         }
     ]
 }

--- a/app/AppInspector/metadata/view/FilterField
+++ b/app/AppInspector/metadata/view/FilterField
@@ -75,6 +75,24 @@
                 "scope": "me"
             },
             "designerId": "10a2fb72-d45a-4700-bf7e-4e97012efdf2"
+        },
+        {
+            "type": "basiceventbinding",
+            "reference": {
+                "name": "listeners",
+                "type": "array"
+            },
+            "codeClass": null,
+            "userConfig": {
+                "fn": "onTextfieldBeforeRender",
+                "implHandler": [
+                    "this.emptyText = AI.util.i18n.getMessage(this.emptyText);",
+                    ""
+                ],
+                "name": "beforerender",
+                "scope": "me"
+            },
+            "designerId": "c57d85e5-a255-4693-9520-9c5a9acaef72"
         }
     ]
 }

--- a/app/AppInspector/metadata/view/Layouts
+++ b/app/AppInspector/metadata/view/Layouts
@@ -323,6 +323,24 @@
                     ]
                 }
             ]
+        },
+        {
+            "type": "basiceventbinding",
+            "reference": {
+                "name": "listeners",
+                "type": "array"
+            },
+            "codeClass": null,
+            "userConfig": {
+                "fn": "onLayoutInspectorBeforeAdd",
+                "implHandler": [
+                    "this.setTitle(AI.util.i18n.getMessage(this.title));",
+                    ""
+                ],
+                "name": "beforeadd",
+                "scope": "me"
+            },
+            "designerId": "36057f48-0e3e-4ddc-91f9-bdec06cf69fc"
         }
     ]
 }

--- a/app/AppInspector/metadata/view/Layouts
+++ b/app/AppInspector/metadata/view/Layouts
@@ -159,9 +159,10 @@
                                         "fn": "handler",
                                         "implHandler": [
                                             "Ext.Msg.alert(",
-                                            "    'Overnesting',",
-                                            "    'Utility to find components which may be overnested inside the application.'",
-                                            ");"
+                                            "    AI.util.i18n.getMessage('Overnesting'),",
+                                            "    AI.util.i18n.getMessage('Utility to find components which may be overnested inside the application.')",
+                                            ");",
+                                            ""
                                         ]
                                     },
                                     "designerId": "cfcea575-4329-417e-986d-a5e28ae4d5e5"
@@ -311,9 +312,10 @@
                                         "fn": "handler",
                                         "implHandler": [
                                             "Ext.Msg.alert(",
-                                            "    'Box Layouts',",
-                                            "    'Utility to find nested box layouts inside the application which may contribute to performance issues.'",
-                                            ");"
+                                            "    AI.util.i18n.getMessage('Box Layouts'),",
+                                            "    AI.util.i18n.getMessage('Utility to find nested box layouts inside the application which may contribute to performance issues.')",
+                                            ");",
+                                            ""
                                         ]
                                     },
                                     "designerId": "d9246067-7066-49c6-a727-1c3c4c6757dc"

--- a/app/AppInspector/metadata/view/Stores
+++ b/app/AppInspector/metadata/view/Stores
@@ -228,6 +228,24 @@
                     "designerId": "5366c649-9898-4417-9809-34f6905409a0"
                 }
             ]
+        },
+        {
+            "type": "basiceventbinding",
+            "reference": {
+                "name": "listeners",
+                "type": "array"
+            },
+            "codeClass": null,
+            "userConfig": {
+                "fn": "onStoreInspectorBeforeAdd",
+                "implHandler": [
+                    "this.setTitle(AI.util.i18n.getMessage(this.title));",
+                    ""
+                ],
+                "name": "beforeadd",
+                "scope": "me"
+            },
+            "designerId": "1226d648-b12f-4283-a3b3-0ca214e53b93"
         }
     ]
 }

--- a/app/_locales/ja/messages.json
+++ b/app/_locales/ja/messages.json
@@ -1,6 +1,90 @@
 {
     "appDescription": {
-	"message": "Sencha™アプリケーションをデバッグするためのGoogle Chrome™開発ツールエクステンション.",
-	"description": "The description of the application"
+	    "message": "Sencha™ アプリケーションをデバッグするための Google Chrome™ デベロッパーツール拡張",
+	    "description": "The description of the application"
+    },
+    "App_Details": {
+        "message": "アプリ詳細",
+        "description": "The caption of the about panel"
+    },
+    "Components": {
+        "message": "コンポーネント",
+        "description": "The caption of the components panel"
+    },
+    "Stores": {
+        "message": "ストア",
+        "description": "The caption of the store panel"
+    },
+    "Layouts": {
+        "message": "レイアウト",
+        "description": "The caption of the layout panel"
+    },
+    "Events": {
+        "message": "イベント",
+        "description": "The caption of the event panel"
+    },
+    "About_App_Inspector_for_Sencha": {
+        "message": "App Inspector for Sencha について",
+        "description": ""
+    },
+    "Refresh": {
+        "message": "更新",
+        "description": "The caption of the refresh button"
+    },
+    "Filter": {
+        "message": "検索",
+        "description": "The empty text of the filter field"
+    },
+    "Properties": {
+        "message": "プロパティ",
+        "description": "The properties header of the property grid"
+    },
+    "Methods": {
+        "message": "メソッド",
+        "description": "The methods header of the property grid"
+    },
+    "Store_Records": {
+        "message": "Store のレコード",
+        "description": "The panel title of the Store Records"
+    },
+    "Record_Details": {
+        "message": "レコード詳細",
+        "description": "The panel title of the Records Details"
+    },
+    "Profile": {
+        "message": "プロファイル",
+        "description": "The caption of the about panel"
+    },
+    "Overnesting": {
+        "message": "過剰なネスト",
+        "description": "The tab title of the Overnesting"
+    },
+    "Box_Layouts": {
+        "message": "ボックスレイアウト",
+        "description": "The tab title of the Box Layouts"
+    },
+    "Clear": {
+        "message": "クリア",
+        "description": "The caption of the Clear button"
+    },
+    "Record": {
+        "message": "記録",
+        "description": "The caption of the Record button"
+    },
+    "Stop_Recording": {
+        "message": "記録の停止",
+        "description": "The caption of the Stop Record button"
+    },
+    "Sort_Ascending": {
+        "message": "昇順",
+        "description": "The caption of the Sort Ascending"
+    },
+    "Sort_Descending": {
+        "message": "降順",
+        "description": "The caption of the Sort Descending"
+    },
+    "Columns": {
+        "message": "カラム",
+        "description": "The caption of the Columns"
     }
 }

--- a/app/_locales/ja/messages.json
+++ b/app/_locales/ja/messages.json
@@ -1,7 +1,7 @@
 {
     "appDescription": {
-	    "message": "Sencha™ アプリケーションをデバッグするための Google Chrome™ デベロッパーツール拡張",
-	    "description": "The description of the application"
+        "message": "Sencha™ アプリケーションをデバッグするための Google Chrome™ デベロッパーツール拡張",
+        "description": "The description of the application"
     },
     "App_Details": {
         "message": "アプリ詳細",

--- a/app/_locales/ja/messages.json
+++ b/app/_locales/ja/messages.json
@@ -86,5 +86,13 @@
     "Columns": {
         "message": "カラム",
         "description": "The caption of the Columns"
+    },
+    "Utility_to_find_components_which_may_be_overnested_inside_the_application": {
+        "message": "アプリケーション内で過剰にネストされているコンポーネントを探す機能です。",
+        "description": "The description about Overnesting"
+    },
+    "Utility_to_find_nested_box_layouts_inside_the_application_which_may_contribute_to_performance_issues": {
+        "message": "アプリケーション内でネストされているボックスレイアウトを探す機能です。ボックスレイアウトはパフォーマンス上の問題を発生させる場合があります。",
+        "description": "The description about Overnesting"
     }
 }


### PR DESCRIPTION
You can change the value of "title", "text" or "name" property by chrome i18n message catalog.

ex)
title:
'About App Inspector for Sencha'
to
'App Inspector for Sencha について'

It allows the message key which contains space value. If doesn't exist a message in the catalog, use it just as it is.

![i18n](https://f.cloud.github.com/assets/321647/2447730/2d30f568-ae9c-11e3-9993-1e648831797f.png)
