### PR TITLE
Fix for issue #50.

### DIFF
--- a/app/AppInspector/app/model/Event.js
+++ b/app/AppInspector/app/model/Event.js
@@ -31,7 +31,7 @@ Ext.define('AI.model.Event', {
             name: 'source'
         },
         {
-            name: 'id'
+            name: 'cmpId'
         }
     ]
 });

--- a/app/AppInspector/app/util/extjs/Events.js
+++ b/app/AppInspector/app/util/extjs/Events.js
@@ -42,7 +42,7 @@ Ext.define('AI.util.extjs.Events', {
                     eventName : eventName,
                     source    : signature.$className,
                     xtype     : signature.xtype,
-                    id        : signature.id
+                    cmpId     : signature.id
                 });
             };
 

--- a/app/AppInspector/app/util/touch/Events.js
+++ b/app/AppInspector/app/util/touch/Events.js
@@ -23,7 +23,7 @@ Ext.define('AI.util.touch.Events', {
                     eventName : eventName,
                     source    : (isComponent) ? arguments[3][0].$className : targetType,
                     xtype     : (isComponent) ? arguments[3][0].xtype : '',
-                    id        : target
+                    cmpId     : target
                 };
 
                 Ext.ux.AppInspector.eventCache.push(x);

--- a/app/AppInspector/app/view/Events.js
+++ b/app/AppInspector/app/view/Events.js
@@ -90,7 +90,7 @@ Ext.define('AI.view.Events', {
                 },
                 {
                     xtype: 'gridcolumn',
-                    dataIndex: 'id',
+                    dataIndex: 'cmpId',
                     text: 'Cmp ID',
                     flex: 1
                 }

--- a/app/AppInspector/metadata/model/Event
+++ b/app/AppInspector/metadata/model/Event
@@ -54,7 +54,7 @@
             },
             "codeClass": null,
             "userConfig": {
-                "name": "id"
+                "name": "cmpId"
             },
             "designerId": "472da607-58b2-4c28-aa76-0e40a02cc3aa"
         }

--- a/app/AppInspector/metadata/view/Events
+++ b/app/AppInspector/metadata/view/Events
@@ -154,7 +154,7 @@
             },
             "codeClass": null,
             "userConfig": {
-                "dataIndex": "id",
+                "dataIndex": "cmpId",
                 "flex": 1,
                 "text": "Cmp ID"
             },


### PR DESCRIPTION
I had carlessly used "id" as a model field name. On sorting the grid, the store pruned any "duplicate" records.
