### PR TITLE
Add the grunt task to run the tests on Siesta Lite.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -3,4 +3,4 @@
 * [Bruno Tavares](https://github.com/brunotavares) http://bruno.tavares.me (Creator)
 * [Arthur Kay](https://github.com/arthurakay) http://www.akawebdesign.com
 * [Stefan Stölzle](https://github.com/stoe) http://stefan.stoelzle.me
-* [Shinobu Kawano](https://github.com/kawanoshinobu) http://kawanoshinobu.com
+* [KAWANO Shinobu](https://github.com/kawanoshinobu) http://kawanoshinobu.com

--- a/GruntJS.md
+++ b/GruntJS.md
@@ -14,6 +14,9 @@ Generate the projects documentation. Subsequently running [`clean:docs`](#the-cl
 ### `grunt dev`
 Build the project. Subsequently running [`jshint`](#the-jshint-task), [`clean:dist`](#the-clean-task), [`chromeManifest:dist`](#the-chromemanifest-task), [`exec:dev`](#the-exec-task) and [`copy:dev`](#the-copy-task) tasks.
 
+### `grunt test`
+Run the tests. Subsequently running [`connect`](#the-connect-) task.
+
 ### `grunt build`
 Build the project. Subsequently running [`jshint`](#the-jshint-task), [`clean:dist`](#the-clean-task), [`chromeManifest:dist`](#the-chromemanifest-task), [`exec:production`](#the-exec-task), [`imagemin`](#the-imagemin-task), [`copy:dist`](#the-copy-task), [`compress`](#the-compress-task) and [`docs`](#grunt-docs) tasks.
 
@@ -108,3 +111,13 @@ It uses the `.jshintrc` file containing the linting rules.
 Read more on:
 * https://www.npmjs.org/package/grunt-contrib-jshint
 * http://www.jshint.com/docs/
+
+#### The `connect` task
+
+Start a connect web server for running the tests on Siesta Lite. It opens the Siesta's test page in your default browser.
+
+The port number will be used in 8333, but if you have already used it, please change it as you like.
+
+Read more on:
+* https://www.npmjs.org/package/grunt-contrib-connect
+

--- a/app/AppInspector/about.html
+++ b/app/AppInspector/about.html
@@ -14,5 +14,5 @@
     <li><a href="http://www.akawebdesign.com" target="_blank">Arthur Kay</a></li>
     <li><a href="http://stefan.stoelzle.me" target="_blank">Stefan Stölzle</a></li>
     <li><a href="http://bruno.tavares.me" target="_blank">Bruno Tavares</a></li>
-    <li><a href="http://kawanoshinobu.com" target="_blank">Shinobu Kawano</a></li>
+    <li><a href="http://kawanoshinobu.com" target="_blank">KAWANO Shinobu</a></li>
 </ul>

--- a/app/test/index.js
+++ b/app/test/index.js
@@ -13,7 +13,8 @@ Harness.start(
             'AI' : '../AppInspector/app'
         },
 
-        hostPageUrl : 'http://sencha.local/_touch/touch-2.3.1/examples/list/index.html',
+        // hostPageUrl : 'http://sencha.local/_touch/touch-2.3.1/examples/list/index.html',
+        hostPageUrl : '../../../_touch/touch-2.3.1/examples/list/index.html',
 
         items : [
             'specs/touch/InspectedWindow.js',
@@ -34,7 +35,8 @@ Harness.start(
         },
 
         //hostPageUrl : 'http://sencha.local/_ext/ext-4.2.1.883/examples/personel-review/index.html',
-        hostPageUrl : 'http://sencha.local/_ext/ext-4.2.1.883/examples/kitchensink/#basic-panels',
+        // hostPageUrl : 'http://localhost/_ext/ext-4.2.1.883/examples/kitchensink/#basic-panels',
+        hostPageUrl : '../../../_ext/ext-4.2.1.883/examples/kitchensink/#basic-panels',
 
         items : [
             'specs/ext4/InspectedWindow.js',
@@ -50,7 +52,8 @@ Harness.start(
             'AI' : '../AppInspector/app'
         },
 
-        hostPageUrl : 'http://sencha.local/_ext/ext5-qa/ext/examples/kitchensink/#basic-panels',
+        // hostPageUrl : 'http://sencha.local/_ext/ext5-qa/ext/examples/kitchensink/#basic-panels',
+        hostPageUrl : '../../../_ext/ext5-qa/ext/examples/kitchensink/#basic-panels',
 
         items : [
             'specs/ext5/InspectedWindow.js',

--- a/grunt/aliases.js
+++ b/grunt/aliases.js
@@ -15,6 +15,9 @@ module.exports = {
         'copy:dev',
         'fileblocks:dist'
     ],
+    test    : [
+        'connect'
+    ],
     build   : [
         'jshint',
         'clean:dist',

--- a/grunt/connect.js
+++ b/grunt/connect.js
@@ -1,0 +1,21 @@
+'use strict';
+
+/**
+ * Start a connect web server.
+ * @type {Object}
+ *
+ * @see https://www.npmjs.org/package/grunt-contrib-connect
+ */
+module.exports = {
+    server : {
+        options : {
+            hostname  : 'localhost',
+            port      : 8333,
+            base      : '../',
+            keepalive : true,
+            open      : {
+                target : 'http://localhost:8333/appinspector/app/test'
+            }
+        }
+    }
+};

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     }, {
         "name": "Stefan Stölzle",
         "url": "https://github.com/stoe"
+    }, {
+        "name": "KAWANO Shinobu",
+        "url": "https://github.com/kawanoshinobu"
     }],
     "repository": {
         "type": "git",
@@ -24,6 +27,7 @@
         "grunt-chrome-manifest": "~0.2.0",
         "grunt-contrib-clean": "~0.5.0",
         "grunt-contrib-compress": "~0.7.0",
+        "grunt-contrib-connect": "~0.7.1",
         "grunt-contrib-copy": "~0.5.0",
         "grunt-contrib-imagemin": "~0.2.0",
         "grunt-contrib-jshint": "~0.8.0",


### PR DESCRIPTION
ref #61
- It starts a connect web server for running the tests on Siesta Lite.
- It opens the Siesta's test page in your default browser.
- The port number will be used in 8333, but if you have already used it, please change it as you like.
