### PR TITLE
feat(components): cell editor added to component details

### DIFF
--- a/app/AppInspector/app/controller/Components.js
+++ b/app/AppInspector/app/controller/Components.js
@@ -52,7 +52,8 @@ Ext.define('AI.controller.Components', {
             },
             // properties
             'gridpanel#ComponentProps': {
-                'activate': me.toggleComponentsDetailsTips
+                'activate': me.toggleComponentsDetailsTips,
+                'validateedit': me.onDetailValueEdit
             },
             'gridpanel#ComponentProps filterfield': {
                 'applyfilter': me.onFilterComponentDetails
@@ -182,6 +183,11 @@ Ext.define('AI.controller.Components', {
                 value: value
             }]);
         }
+    },
+
+    onDetailValueEdit: function() {
+        // cancel edit to reset original value
+        return false;
     }
 
 });

--- a/app/AppInspector/app/view/Components.js
+++ b/app/AppInspector/app/view/Components.js
@@ -29,6 +29,7 @@ Ext.define('AI.view.Components', {
         'Ext.grid.View',
         'Ext.grid.column.Boolean',
         'Ext.tab.Tab',
+        'Ext.grid.plugin.CellEditing',
         'Ext.toolbar.TextItem',
         'Ext.layout.container.Border'
     ],
@@ -123,8 +124,17 @@ Ext.define('AI.view.Components', {
                                     xtype: 'gridcolumn',
                                     dataIndex: 'value',
                                     text: 'Value',
-                                    flex: 1
+                                    flex: 1,
+                                    editor: {
+                                        xtype: 'textfield',
+                                        selectOnFocus: true
+                                    }
                                 }
+                            ],
+                            plugins: [
+                                Ext.create('Ext.grid.plugin.CellEditing', {
+
+                                })
                             ]
                         },
                         {

--- a/app/AppInspector/metadata/controller/Components
+++ b/app/AppInspector/metadata/controller/Components
@@ -56,7 +56,8 @@
                     "    },",
                     "    // properties",
                     "    'gridpanel#ComponentProps': {",
-                    "        'activate': me.toggleComponentsDetailsTips",
+                    "        'activate': me.toggleComponentsDetailsTips,",
+                    "        'validateedit': me.onDetailValueEdit",
                     "    },",
                     "    'gridpanel#ComponentProps filterfield': {",
                     "        'applyfilter': me.onFilterComponentDetails",
@@ -289,6 +290,22 @@
                 ]
             },
             "designerId": "b19705e2-d90c-45cc-a8ad-7c1dbb815cb8"
+        },
+        {
+            "type": "basicfunction",
+            "reference": {
+                "name": "items",
+                "type": "array"
+            },
+            "codeClass": null,
+            "userConfig": {
+                "fn": "onDetailValueEdit",
+                "implHandler": [
+                    "// cancel edit to reset original value",
+                    "return false;"
+                ]
+            },
+            "designerId": "fa3786ff-760f-4952-956e-8e03efee7089"
         }
     ]
 }

--- a/app/AppInspector/metadata/view/Components
+++ b/app/AppInspector/metadata/view/Components
@@ -233,7 +233,21 @@
                                 "flex": 1,
                                 "text": "Value"
                             },
-                            "designerId": "94651013-15f2-45bc-bcf2-d49d954dc75f"
+                            "designerId": "94651013-15f2-45bc-bcf2-d49d954dc75f",
+                            "cn": [
+                                {
+                                    "type": "Ext.form.field.Text",
+                                    "reference": {
+                                        "name": "editor",
+                                        "type": "object"
+                                    },
+                                    "codeClass": null,
+                                    "userConfig": {
+                                        "selectOnFocus": true
+                                    },
+                                    "designerId": "26989453-d6e9-4455-be62-3b9e878bf35d"
+                                }
+                            ]
                         },
                         {
                             "type": "Ext.tab.Tab",
@@ -243,6 +257,15 @@
                             },
                             "codeClass": null,
                             "designerId": "6a0c1d1b-fe18-463d-b860-1f7817324449"
+                        },
+                        {
+                            "type": "Ext.grid.plugin.CellEditing",
+                            "reference": {
+                                "name": "plugins",
+                                "type": "array"
+                            },
+                            "codeClass": "Ext.grid.plugin.CellEditing",
+                            "designerId": "7e31e4e3-dc0a-4b44-8f50-f94c353c1609"
                         }
                     ]
                 },


### PR DESCRIPTION
Added a select on focus [Ext.grid.plugin.CellEditing](http://docs.sencha.com/ext/5.0.0/apidocs/#!/api/Ext.grid.plugin.CellEditing-event-validateedit) to _Components > Properties > Value_ so the value can be C&P'ed.

Request through Chrome Webstore:

> Andrew Barfield (https://plus.google.com/+AndrewBarfield) - Feb 25, 2014
> 
> ...
> 2) Allow us to 'copy to clipboard' via context menu.
> ...
